### PR TITLE
camellia: Add AUDIO_STREAMING_LOW_LATENCY hints

### DIFF
--- a/configs/perf/powerhint.json
+++ b/configs/perf/powerhint.json
@@ -368,6 +368,24 @@
       "Node": "GPUBlockBoost",
       "Duration": 0,
       "Value": "50"
+    },
+    {
+      "PowerHint": "AUDIO_STREAMING_LOW_LATENCY",
+      "Node": "PowerHALAudioState",
+      "Duration": 0,
+      "Value": "AUDIO_STREAMING_LOW_LATENCY"
+    },
+    {
+      "PowerHint": "AUDIO_STREAMING_LOW_LATENCY",
+      "Node": "CPULittleClusterMinFreq",
+      "Duration": 0,
+      "Value": "840000"
+    },
+    {
+      "PowerHint": "AUDIO_STREAMING_LOW_LATENCY",
+      "Node": "CPUBigClusterMinFreq",
+      "Duration": 0,
+      "Value": "1042000"
     }
   ]
 }

--- a/sepolicy/vendor/mtk_hal_power.te
+++ b/sepolicy/vendor/mtk_hal_power.te
@@ -10,3 +10,6 @@ set_prop(mtk_hal_camera, vendor_camera_prop)
 get_prop(mtk_hal_camera, vendor_camera_prop)
 get_prop(mtk_hal_camera, vendor_mtk_pq_prop)
 get_prop(mtk_hal_camera, vendor_mtk_pq_ro_prop)
+
+# Allow mtkpower stub service to call powerhal
+binder_call(mtk_hal_power, hal_power_default)


### PR DESCRIPTION
* Boosts CPU while playing audio / when requested by the audio HAL. This fixes poor sound quality in some games.

Change-Id: I2d890747f0362e5b25a8f8b4b267d49f5fc9c165